### PR TITLE
Added support for CuArray via Adapt.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,8 +3,17 @@ uuid = "1277b4bf-5013-50f5-be3d-901d8477a67a"
 repo = "https://github.com/JuliaArrays/ShiftedArrays.jl.git"
 version = "2.0.0"
 
+[weakdeps]
+CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
+Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
+
+[extensions]
+CUDASupportExt = ["CUDA", "Adapt"]
+
 [compat]
-julia = "1"
+CUDA = "5.1.1"
+Adapt = "3.7.2"
+julia = "1.9"
 
 [extras]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/Project.toml
+++ b/Project.toml
@@ -11,9 +11,9 @@ Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
 CUDASupportExt = ["CUDA", "Adapt"]
 
 [compat]
-CUDA = "5.1.1"
-Adapt = "3.7.2"
-julia = "1.9"
+CUDA = "5.2, 5.3, 5.4, 5.5, 5.6"
+Adapt = "3.7, 4.0, 4.1"
+julia = "1.9, 1.10, 1.11"
 
 [extras]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/ext/CUDASupportExt.jl
+++ b/ext/CUDASupportExt.jl
@@ -4,7 +4,7 @@ using Adapt
 using ShiftedArrays
 using Base # to allow displaying such arrays without causing the single indexing CUDA error
 
-Adapt.adapt_structure(to, x::CircShiftedArray{T, D, CT}) where {T,D,CT<:CuArray} = CircShiftedArray(adapt(to, parent(x)), shifts(x));
+Adapt.adapt_structure(to, x::CircShiftedArray{T, D}) where {T, D} = CircShiftedArray(adapt(to, parent(x)), shifts(x));
 function Base.Broadcast.BroadcastStyle(::Type{T})  where (T<: CircShiftedArray{<:Any,<:Any,<:CuArray})
     CUDA.CuArrayStyle{ndims(T)}()
 end

--- a/ext/CUDASupportExt.jl
+++ b/ext/CUDASupportExt.jl
@@ -1,0 +1,26 @@
+module CUDASupportExt
+using CUDA 
+using Adapt
+using ShiftedArrays
+using Base # to allow displaying such arrays without causing the single indexing CUDA error
+
+Adapt.adapt_structure(to, x::CircShiftedArray{T, D, CT}) where {T,D,CT<:CuArray} = CircShiftedArray(adapt(to, parent(x)), shifts(x));
+function Base.Broadcast.BroadcastStyle(::Type{T})  where (T<: CircShiftedArray{<:Any,<:Any,<:CuArray})
+    CUDA.CuArrayStyle{ndims(T)}()
+end
+
+Adapt.adapt_structure(to, x::ShiftedArray{T, M, N, <:CuArray}) where {T,M,N} =
+# lets do this for the ShiftedArray type
+ShiftedArray(adapt(to, parent(x)), shifts(x); default=ShiftedArrays.default(x))
+function Base.Broadcast.BroadcastStyle(::Type{T})  where (T<: ShiftedArray{<:Any,<:Any,<:Any,<:CuArray})
+    CUDA.CuArrayStyle{ndims(T)}()
+end
+
+function Base.show(io::IO, mm::MIME"text/plain", cs::CircShiftedArray) 
+    CUDA.@allowscalar invoke(Base.show, Tuple{IO, typeof(mm), AbstractArray}, io, mm, cs) 
+end
+
+function Base.show(io::IO, mm::MIME"text/plain", cs::ShiftedArray) 
+    CUDA.@allowscalar invoke(Base.show, Tuple{IO, typeof(mm), AbstractArray}, io, mm, cs) 
+end
+end

--- a/ext/CUDASupportExt.jl
+++ b/ext/CUDASupportExt.jl
@@ -9,7 +9,7 @@ function Base.Broadcast.BroadcastStyle(::Type{T})  where (T<: CircShiftedArray{<
     CUDA.CuArrayStyle{ndims(T)}()
 end
 
-Adapt.adapt_structure(to, x::ShiftedArray{T, M, N, <:CuArray}) where {T,M,N} =
+Adapt.adapt_structure(to, x::ShiftedArray{T, M, N}) where {T, M, N} =
 # lets do this for the ShiftedArray type
 ShiftedArray(adapt(to, parent(x)), shifts(x); default=ShiftedArrays.default(x))
 function Base.Broadcast.BroadcastStyle(::Type{T})  where (T<: ShiftedArray{<:Any,<:Any,<:Any,<:CuArray})

--- a/ext/CUDASupportExt.jl
+++ b/ext/CUDASupportExt.jl
@@ -5,21 +5,20 @@ using ShiftedArrays
 using Base # to allow displaying such arrays without causing the single indexing CUDA error
 
 Adapt.adapt_structure(to, x::CircShiftedArray{T, D}) where {T, D} = CircShiftedArray(adapt(to, parent(x)), shifts(x));
-parent_type(::Type{CircShiftedArray{T, N, S})  where {T, N, S} = S
-Base.Broadcast.BroadcastStyle(::Type{T})  where (T<:CircShiftedArray} = Base.Broadcast.BroadcastStyle(parent_type(T))
+parent_type(::Type{CircShiftedArray{T, N, S}})  where {T, N, S} = S
+Base.Broadcast.BroadcastStyle(::Type{T})  where {T<:CircShiftedArray} = Base.Broadcast.BroadcastStyle(parent_type(T))
 
-Adapt.adapt_structure(to, x::ShiftedArray{T, M, N}) where {T, M, N} =
 # lets do this for the ShiftedArray type
-ShiftedArray(adapt(to, parent(x)), shifts(x); default=ShiftedArrays.default(x))
+Adapt.adapt_structure(to, x::ShiftedArray{T, M, N}) where {T, M, N} = ShiftedArray(adapt(to, parent(x)), shifts(x); default=ShiftedArrays.default(x));
 function Base.Broadcast.BroadcastStyle(::Type{T})  where (T<: ShiftedArray{<:Any,<:Any,<:Any,<:CuArray})
     CUDA.CuArrayStyle{ndims(T)}()
 end
 
-function Base.show(io::IO, mm::MIME"text/plain", cs::CircShiftedArray) 
-    CUDA.@allowscalar invoke(Base.show, Tuple{IO, typeof(mm), AbstractArray}, io, mm, cs) 
-end
+# function Base.show(io::IO, mm::MIME"text/plain", cs::CircShiftedArray) 
+#     CUDA.@allowscalar invoke(Base.show, Tuple{IO, typeof(mm), AbstractArray}, io, mm, cs) 
+# end
 
-function Base.show(io::IO, mm::MIME"text/plain", cs::ShiftedArray) 
-    CUDA.@allowscalar invoke(Base.show, Tuple{IO, typeof(mm), AbstractArray}, io, mm, cs) 
-end
+# function Base.show(io::IO, mm::MIME"text/plain", cs::ShiftedArray) 
+#     CUDA.@allowscalar invoke(Base.show, Tuple{IO, typeof(mm), AbstractArray}, io, mm, cs) 
+# end
 end

--- a/ext/CUDASupportExt.jl
+++ b/ext/CUDASupportExt.jl
@@ -5,9 +5,8 @@ using ShiftedArrays
 using Base # to allow displaying such arrays without causing the single indexing CUDA error
 
 Adapt.adapt_structure(to, x::CircShiftedArray{T, D}) where {T, D} = CircShiftedArray(adapt(to, parent(x)), shifts(x));
-function Base.Broadcast.BroadcastStyle(::Type{T})  where (T<: CircShiftedArray{<:Any,<:Any,<:CuArray})
-    CUDA.CuArrayStyle{ndims(T)}()
-end
+parent_type(::Type{CircShiftedArray{T, N, S})  where {T, N, S} = S
+Base.Broadcast.BroadcastStyle(::Type{T})  where (T<:CircShiftedArray} = Base.Broadcast.BroadcastStyle(parent_type(T))
 
 Adapt.adapt_structure(to, x::ShiftedArray{T, M, N}) where {T, M, N} =
 # lets do this for the ShiftedArray type

--- a/ext/CUDASupportExt.jl
+++ b/ext/CUDASupportExt.jl
@@ -8,10 +8,13 @@ Adapt.adapt_structure(to, x::CircShiftedArray{T, D}) where {T, D} = CircShiftedA
 parent_type(::Type{CircShiftedArray{T, N, S}})  where {T, N, S} = S
 Base.Broadcast.BroadcastStyle(::Type{T})  where {T<:CircShiftedArray} = Base.Broadcast.BroadcastStyle(parent_type(T))
 
+# cu_storage_type(::Type{T}) where {CT,CN,CD,T<:CuArray{CT,CN,CD}} = CD
 # lets do this for the ShiftedArray type
 Adapt.adapt_structure(to, x::ShiftedArray{T, M, N}) where {T, M, N} = ShiftedArray(adapt(to, parent(x)), shifts(x); default=ShiftedArrays.default(x));
-function Base.Broadcast.BroadcastStyle(::Type{T})  where (T<: ShiftedArray{<:Any,<:Any,<:Any,<:CuArray})
-    CUDA.CuArrayStyle{ndims(T)}()
+
+# function Base.Broadcast.BroadcastStyle(::Type{T})  where (CT,CN,CD,T<: ShiftedArray{<:Any,<:Any,<:Any,<:CuArray})
+function Base.Broadcast.BroadcastStyle(::Type{ShiftedArray{<:Any,<:Any,<:Any, <:CuArray{T,N,CD}}}) where {T,N,CD}
+    CUDA.CuArrayStyle{N,CD}()
 end
 
 # function Base.show(io::IO, mm::MIME"text/plain", cs::CircShiftedArray) 

--- a/ext/CUDASupportExt.jl
+++ b/ext/CUDASupportExt.jl
@@ -13,7 +13,7 @@ Base.Broadcast.BroadcastStyle(::Type{T})  where {T<:CircShiftedArray} = Base.Bro
 Adapt.adapt_structure(to, x::ShiftedArray{T, M, N}) where {T, M, N} = ShiftedArray(adapt(to, parent(x)), shifts(x); default=ShiftedArrays.default(x));
 
 # function Base.Broadcast.BroadcastStyle(::Type{T})  where (CT,CN,CD,T<: ShiftedArray{<:Any,<:Any,<:Any,<:CuArray})
-function Base.Broadcast.BroadcastStyle(::Type{ShiftedArray{<:Any,<:Any,<:Any, <:CuArray{T,N,CD}}}) where {T,N,CD}
+function Base.Broadcast.BroadcastStyle(::Type{T})  where {T2, N, CD, T<:ShiftedArray{<:Any,<:Any,<:Any,<:CuArray{T2,N,CD}}}
     CUDA.CuArrayStyle{N,CD}()
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,6 @@
 using ShiftedArrays, Test
 using AbstractFFTs 
-use_cuda = true;  # set this to true to test ShiftedArrays for the CuArray datatype
+use_cuda = false;  # set this to true to test ShiftedArrays for the CuArray datatype
 if (use_cuda)
     using CUDA
     CUDA.allowscalar(true); # needed for some of the comparisons

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,6 @@
 using ShiftedArrays, Test
 using AbstractFFTs 
-use_cuda = false;  # set this to true to test ShiftedArrays for the CuArray datatype
+use_cuda = true;  # set this to true to test ShiftedArrays for the CuArray datatype
 if (use_cuda)
     using CUDA
     CUDA.allowscalar(true); # needed for some of the comparisons


### PR DESCRIPTION
This second attempt, uses a very light-weight implementation to add `CuArray` support to `ShiftedArrays.jl`.
It is based on using an Extension Package, such that `ShiftedArrays` does not drag in any extra packages, but if `CUDA.jl` is present, the adaptation is used.
Note that the `show()` function was specified by CuArrays preventing errors via the `@allowscalar` macro.
The tests were extended to CuArray usage, but this has to be enabled manually in the `runtests.jl` file.
