### PR TITLE
MutableShiftedArray

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,12 +21,12 @@ jobs:
         arch:
           - x64
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v3
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v1
+      - uses: actions/cache@v3
         env:
           cache-name: cache-artifacts
         with:
@@ -39,18 +39,18 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v3
         with:
           file: lcov.info
   docs:
     name: Documentation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v3
+      - uses: julia-actions/setup-julia@v2
         with:
           version: '1'
-      - uses: julia-actions/julia-docdeploy@releases/v1
+      - uses: julia-actions/julia-docdeploy@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}

--- a/Project.toml
+++ b/Project.toml
@@ -3,8 +3,17 @@ uuid = "1277b4bf-5013-50f5-be3d-901d8477a67a"
 repo = "https://github.com/JuliaArrays/ShiftedArrays.jl.git"
 version = "2.0.0"
 
+[weakdeps]
+CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
+Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
+
+[extensions]
+CUDASupportExt = ["CUDA", "Adapt"]
+
 [compat]
-julia = "1"
+CUDA = "5.1.1"
+Adapt = "3.7.2"
+julia = "1.9"
 
 [extras]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/Project.toml
+++ b/Project.toml
@@ -11,9 +11,9 @@ Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
 CUDASupportExt = ["CUDA", "Adapt"]
 
 [compat]
-CUDA = "5.1.1"
-Adapt = "3.7.2"
-julia = "1.9"
+CUDA = "5.2, 5.3, 5.4, 5.5, 5.6"
+Adapt = "3.7, 4.0, 4.1"
+julia = "1.9, 1.10, 1.11"
 
 [extras]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -5,12 +5,18 @@ git-tree-sha1 = "574baf8110975760d391c710b6341da1afa48d8c"
 uuid = "a4c015fc-c6ff-483c-b24f-f7ea428134e9"
 version = "0.0.1"
 
+[[Artifacts]]
+uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
+version = "1.11.0"
+
 [[Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+version = "1.11.0"
 
 [[Dates]]
 deps = ["Printf"]
 uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+version = "1.11.0"
 
 [[DocStringExtensions]]
 deps = ["LibGit2"]
@@ -33,6 +39,7 @@ version = "0.2.2"
 [[InteractiveUtils]]
 deps = ["Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+version = "1.11.0"
 
 [[JSON]]
 deps = ["Dates", "Mmap", "Parsers", "Unicode"]
@@ -41,18 +48,41 @@ uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 version = "0.21.3"
 
 [[LibGit2]]
-deps = ["Base64", "NetworkOptions", "Printf", "SHA"]
+deps = ["Base64", "LibGit2_jll", "NetworkOptions", "Printf", "SHA"]
 uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+version = "1.11.0"
+
+[[LibGit2_jll]]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll"]
+uuid = "e37daf67-58a4-590a-8e99-b0245dd2ffc5"
+version = "1.7.2+0"
+
+[[LibSSH2_jll]]
+deps = ["Artifacts", "Libdl", "MbedTLS_jll"]
+uuid = "29816b5a-b9ab-546f-933c-edad1886dfa8"
+version = "1.11.0+1"
+
+[[Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+version = "1.11.0"
 
 [[Logging]]
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+version = "1.11.0"
 
 [[Markdown]]
 deps = ["Base64"]
 uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+version = "1.11.0"
+
+[[MbedTLS_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
+version = "2.28.6+0"
 
 [[Mmap]]
 uuid = "a63ad114-7e13-5084-954f-fe012c677804"
+version = "1.11.0"
 
 [[NetworkOptions]]
 uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
@@ -67,14 +97,17 @@ version = "2.4.0"
 [[Printf]]
 deps = ["Unicode"]
 uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+version = "1.11.0"
 
 [[REPL]]
-deps = ["InteractiveUtils", "Markdown", "Sockets", "Unicode"]
+deps = ["InteractiveUtils", "Markdown", "Sockets", "StyledStrings", "Unicode"]
 uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+version = "1.11.0"
 
 [[Random]]
-deps = ["SHA", "Serialization"]
+deps = ["SHA"]
 uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+version = "1.11.0"
 
 [[SHA]]
 uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
@@ -82,13 +115,33 @@ version = "0.7.0"
 
 [[Serialization]]
 uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+version = "1.11.0"
+
+[[ShiftedArrays]]
+path = ".."
+uuid = "1277b4bf-5013-50f5-be3d-901d8477a67a"
+version = "2.0.0"
+
+    [ShiftedArrays.extensions]
+    CUDASupportExt = ["CUDA", "Adapt"]
+
+    [ShiftedArrays.weakdeps]
+    Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
+    CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 
 [[Sockets]]
 uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+version = "1.11.0"
+
+[[StyledStrings]]
+uuid = "f489334b-da3d-4c2e-b8f0-e476e12c162b"
+version = "1.11.0"
 
 [[Test]]
 deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
 uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+version = "1.11.0"
 
 [[Unicode]]
 uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+version = "1.11.0"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,2 +1,3 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+ShiftedArrays = "1277b4bf-5013-50f5-be3d-901d8477a67a"

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -5,6 +5,8 @@
 ```@docs
 ShiftedArray
 ShiftedVector
+MutableShiftedArray
+MutableShiftedVector
 CircShiftedArray
 CircShiftedVector
 ```

--- a/ext/CUDASupportExt.jl
+++ b/ext/CUDASupportExt.jl
@@ -4,7 +4,7 @@ using Adapt
 using ShiftedArrays
 using Base # to allow displaying such arrays without causing the single indexing CUDA error
 
-Adapt.adapt_structure(to, x::CircShiftedArray{T, D, CT}) where {T,D,CT<:CuArray} = CircShiftedArray(adapt(to, parent(x)), shifts(x));
+Adapt.adapt_structure(to, x::CircShiftedArray{T, D}) where {T, D} = CircShiftedArray(adapt(to, parent(x)), shifts(x));
 function Base.Broadcast.BroadcastStyle(::Type{T})  where (T<: CircShiftedArray{<:Any,<:Any,<:CuArray})
     CUDA.CuArrayStyle{ndims(T)}()
 end

--- a/ext/CUDASupportExt.jl
+++ b/ext/CUDASupportExt.jl
@@ -1,0 +1,26 @@
+module CUDASupportExt
+using CUDA 
+using Adapt
+using ShiftedArrays
+using Base # to allow displaying such arrays without causing the single indexing CUDA error
+
+Adapt.adapt_structure(to, x::CircShiftedArray{T, D, CT}) where {T,D,CT<:CuArray} = CircShiftedArray(adapt(to, parent(x)), shifts(x));
+function Base.Broadcast.BroadcastStyle(::Type{T})  where (T<: CircShiftedArray{<:Any,<:Any,<:CuArray})
+    CUDA.CuArrayStyle{ndims(T)}()
+end
+
+Adapt.adapt_structure(to, x::ShiftedArray{T, M, N, <:CuArray}) where {T,M,N} =
+# lets do this for the ShiftedArray type
+ShiftedArray(adapt(to, parent(x)), shifts(x); default=ShiftedArrays.default(x))
+function Base.Broadcast.BroadcastStyle(::Type{T})  where (T<: ShiftedArray{<:Any,<:Any,<:Any,<:CuArray})
+    CUDA.CuArrayStyle{ndims(T)}()
+end
+
+function Base.show(io::IO, mm::MIME"text/plain", cs::CircShiftedArray) 
+    CUDA.@allowscalar invoke(Base.show, Tuple{IO, typeof(mm), AbstractArray}, io, mm, cs) 
+end
+
+function Base.show(io::IO, mm::MIME"text/plain", cs::ShiftedArray) 
+    CUDA.@allowscalar invoke(Base.show, Tuple{IO, typeof(mm), AbstractArray}, io, mm, cs) 
+end
+end

--- a/ext/CUDASupportExt.jl
+++ b/ext/CUDASupportExt.jl
@@ -9,7 +9,7 @@ function Base.Broadcast.BroadcastStyle(::Type{T})  where (T<: CircShiftedArray{<
     CUDA.CuArrayStyle{ndims(T)}()
 end
 
-Adapt.adapt_structure(to, x::ShiftedArray{T, M, N, <:CuArray}) where {T,M,N} =
+Adapt.adapt_structure(to, x::ShiftedArray{T, M, N}) where {T, M, N} =
 # lets do this for the ShiftedArray type
 ShiftedArray(adapt(to, parent(x)), shifts(x); default=ShiftedArrays.default(x))
 function Base.Broadcast.BroadcastStyle(::Type{T})  where (T<: ShiftedArray{<:Any,<:Any,<:Any,<:CuArray})

--- a/ext/CUDASupportExt.jl
+++ b/ext/CUDASupportExt.jl
@@ -5,21 +5,20 @@ using ShiftedArrays
 using Base # to allow displaying such arrays without causing the single indexing CUDA error
 
 Adapt.adapt_structure(to, x::CircShiftedArray{T, D}) where {T, D} = CircShiftedArray(adapt(to, parent(x)), shifts(x));
-parent_type(::Type{CircShiftedArray{T, N, S})  where {T, N, S} = S
-Base.Broadcast.BroadcastStyle(::Type{T})  where (T<:CircShiftedArray} = Base.Broadcast.BroadcastStyle(parent_type(T))
+parent_type(::Type{CircShiftedArray{T, N, S}})  where {T, N, S} = S
+Base.Broadcast.BroadcastStyle(::Type{T})  where {T<:CircShiftedArray} = Base.Broadcast.BroadcastStyle(parent_type(T))
 
-Adapt.adapt_structure(to, x::ShiftedArray{T, M, N}) where {T, M, N} =
 # lets do this for the ShiftedArray type
-ShiftedArray(adapt(to, parent(x)), shifts(x); default=ShiftedArrays.default(x))
+Adapt.adapt_structure(to, x::ShiftedArray{T, M, N}) where {T, M, N} = ShiftedArray(adapt(to, parent(x)), shifts(x); default=ShiftedArrays.default(x));
 function Base.Broadcast.BroadcastStyle(::Type{T})  where (T<: ShiftedArray{<:Any,<:Any,<:Any,<:CuArray})
     CUDA.CuArrayStyle{ndims(T)}()
 end
 
-function Base.show(io::IO, mm::MIME"text/plain", cs::CircShiftedArray) 
-    CUDA.@allowscalar invoke(Base.show, Tuple{IO, typeof(mm), AbstractArray}, io, mm, cs) 
-end
+# function Base.show(io::IO, mm::MIME"text/plain", cs::CircShiftedArray) 
+#     CUDA.@allowscalar invoke(Base.show, Tuple{IO, typeof(mm), AbstractArray}, io, mm, cs) 
+# end
 
-function Base.show(io::IO, mm::MIME"text/plain", cs::ShiftedArray) 
-    CUDA.@allowscalar invoke(Base.show, Tuple{IO, typeof(mm), AbstractArray}, io, mm, cs) 
-end
+# function Base.show(io::IO, mm::MIME"text/plain", cs::ShiftedArray) 
+#     CUDA.@allowscalar invoke(Base.show, Tuple{IO, typeof(mm), AbstractArray}, io, mm, cs) 
+# end
 end

--- a/ext/CUDASupportExt.jl
+++ b/ext/CUDASupportExt.jl
@@ -5,9 +5,8 @@ using ShiftedArrays
 using Base # to allow displaying such arrays without causing the single indexing CUDA error
 
 Adapt.adapt_structure(to, x::CircShiftedArray{T, D}) where {T, D} = CircShiftedArray(adapt(to, parent(x)), shifts(x));
-function Base.Broadcast.BroadcastStyle(::Type{T})  where (T<: CircShiftedArray{<:Any,<:Any,<:CuArray})
-    CUDA.CuArrayStyle{ndims(T)}()
-end
+parent_type(::Type{CircShiftedArray{T, N, S})  where {T, N, S} = S
+Base.Broadcast.BroadcastStyle(::Type{T})  where (T<:CircShiftedArray} = Base.Broadcast.BroadcastStyle(parent_type(T))
 
 Adapt.adapt_structure(to, x::ShiftedArray{T, M, N}) where {T, M, N} =
 # lets do this for the ShiftedArray type

--- a/ext/CUDASupportExt.jl
+++ b/ext/CUDASupportExt.jl
@@ -17,6 +17,15 @@ function Base.Broadcast.BroadcastStyle(::Type{ShiftedArray{<:Any,<:Any,<:Any, <:
     CUDA.CuArrayStyle{N,CD}()
 end
 
+# cu_storage_type(::Type{T}) where {CT,CN,CD,T<:CuArray{CT,CN,CD}} = CD
+# lets do this for the ShiftedArray type
+Adapt.adapt_structure(to, x::MutableShiftedArray{T, M, N}) where {T, M, N} = MutableShiftedArray(adapt(to, parent(x)), shifts(x); default=ShiftedArrays.default(x));
+
+# function Base.Broadcast.BroadcastStyle(::Type{T})  where (CT,CN,CD,T<: ShiftedArray{<:Any,<:Any,<:Any,<:CuArray})
+function Base.Broadcast.BroadcastStyle(::Type{MutableShiftedArray{<:Any,<:Any,<:Any, <:CuArray{T,N,CD}}}) where {T,N,CD}
+    CUDA.CuArrayStyle{N,CD}()
+end
+
 # function Base.show(io::IO, mm::MIME"text/plain", cs::CircShiftedArray) 
 #     CUDA.@allowscalar invoke(Base.show, Tuple{IO, typeof(mm), AbstractArray}, io, mm, cs) 
 # end

--- a/ext/CUDASupportExt.jl
+++ b/ext/CUDASupportExt.jl
@@ -8,10 +8,13 @@ Adapt.adapt_structure(to, x::CircShiftedArray{T, D}) where {T, D} = CircShiftedA
 parent_type(::Type{CircShiftedArray{T, N, S}})  where {T, N, S} = S
 Base.Broadcast.BroadcastStyle(::Type{T})  where {T<:CircShiftedArray} = Base.Broadcast.BroadcastStyle(parent_type(T))
 
+# cu_storage_type(::Type{T}) where {CT,CN,CD,T<:CuArray{CT,CN,CD}} = CD
 # lets do this for the ShiftedArray type
 Adapt.adapt_structure(to, x::ShiftedArray{T, M, N}) where {T, M, N} = ShiftedArray(adapt(to, parent(x)), shifts(x); default=ShiftedArrays.default(x));
-function Base.Broadcast.BroadcastStyle(::Type{T})  where (T<: ShiftedArray{<:Any,<:Any,<:Any,<:CuArray})
-    CUDA.CuArrayStyle{ndims(T)}()
+
+# function Base.Broadcast.BroadcastStyle(::Type{T})  where (CT,CN,CD,T<: ShiftedArray{<:Any,<:Any,<:Any,<:CuArray})
+function Base.Broadcast.BroadcastStyle(::Type{ShiftedArray{<:Any,<:Any,<:Any, <:CuArray{T,N,CD}}}) where {T,N,CD}
+    CUDA.CuArrayStyle{N,CD}()
 end
 
 # function Base.show(io::IO, mm::MIME"text/plain", cs::CircShiftedArray) 

--- a/ext/CUDASupportExt.jl
+++ b/ext/CUDASupportExt.jl
@@ -12,8 +12,7 @@ Base.Broadcast.BroadcastStyle(::Type{T})  where {T<:CircShiftedArray} = Base.Bro
 # lets do this for the ShiftedArray type
 Adapt.adapt_structure(to, x::ShiftedArray{T, M, N}) where {T, M, N} = ShiftedArray(adapt(to, parent(x)), shifts(x); default=ShiftedArrays.default(x));
 
-# function Base.Broadcast.BroadcastStyle(::Type{T})  where (CT,CN,CD,T<: ShiftedArray{<:Any,<:Any,<:Any,<:CuArray})
-function Base.Broadcast.BroadcastStyle(::Type{ShiftedArray{<:Any,<:Any,<:Any, <:CuArray{T,N,CD}}}) where {T,N,CD}
+function Base.Broadcast.BroadcastStyle(::Type{T})  where {T2, N, CD, T<:ShiftedArray{<:Any,<:Any,<:Any,<:CuArray{T2,N,CD}}}
     CUDA.CuArrayStyle{N,CD}()
 end
 
@@ -21,9 +20,8 @@ end
 # lets do this for the ShiftedArray type
 Adapt.adapt_structure(to, x::MutableShiftedArray{T, M, N}) where {T, M, N} = MutableShiftedArray(adapt(to, parent(x)), shifts(x); default=ShiftedArrays.default(x));
 
-# function Base.Broadcast.BroadcastStyle(::Type{T})  where (CT,CN,CD,T<: ShiftedArray{<:Any,<:Any,<:Any,<:CuArray})
-function Base.Broadcast.BroadcastStyle(::Type{MutableShiftedArray{<:Any,<:Any,<:Any, <:CuArray{T,N,CD}}}) where {T,N,CD}
-    CUDA.CuArrayStyle{N,CD}()
+function Base.Broadcast.BroadcastStyle(::Type{T})  where {T2, N, CD, T<:MutableShiftedArray{<:Any,<:Any,<:Any,<:CuArray{T2,N,CD}}}
+        CUDA.CuArrayStyle{N,CD}()
 end
 
 # function Base.show(io::IO, mm::MIME"text/plain", cs::CircShiftedArray) 

--- a/src/ShiftedArrays.jl
+++ b/src/ShiftedArrays.jl
@@ -2,9 +2,11 @@ module ShiftedArrays
 
 import Base: checkbounds, getindex, setindex!, parent, size, axes
 export ShiftedArray, ShiftedVector, shifts, default
+export MutableShiftedArray, MutableShiftedVector
 export CircShiftedArray, CircShiftedVector
 
 include("shiftedarray.jl")
+include("mutableshiftedarray.jl")
 include("circshiftedarray.jl")
 include("lag.jl")
 include("circshift.jl")

--- a/src/mutableshiftedarray.jl
+++ b/src/mutableshiftedarray.jl
@@ -20,16 +20,7 @@ The recommended constructor is `MutableShiftedArray(parent, shifts; default = mi
 julia> v = [1, 3, 5, 4];
 
 julia> s = MutableShiftedArray(v, (1,))
-4-element MutableShiftedArray{Int64, Missing, Vector{Int64}}:
-  missing
- 1
- 3
- 5
-
-julia> v = [1, 3, 5, 4];
-
-julia> s = MutableShiftedArray(v, (1,))
-4-element MutableShiftedArray{Int64, Missing, Vector{Int64}}:
+4-element MutableShiftedVector{Int64, Missing, Vector{Int64}}:
   missing
  1
  3

--- a/src/mutableshiftedarray.jl
+++ b/src/mutableshiftedarray.jl
@@ -1,0 +1,130 @@
+"""
+    MutableShiftedArray(parent::AbstractArray, shifts, default)
+
+Custom `AbstractArray` object to store an `AbstractArray` `parent` shifted by `shifts` steps
+(where `shifts` is a `Tuple` with one `shift` value per dimension of `parent`).
+As opposed to `ShiftedArray`, this object is mutable and mutation operations in the padded ranges are ignored.
+For `s::MutableShiftedArray`, `s[i...] == s.parent[map(-, i, s.shifts)...]` if `map(-, i, s.shifts)`
+is a valid index for `s.parent`, and `s.v[i, ...] == default` otherwise.
+Use `copy` to collect the values of a `MutableShiftedArray` into a normal `Array`.
+The recommended constructor is `MutableShiftedArray(parent, shifts; default = missing)`.
+
+!!! note
+    If `parent` is itself a `MutableShiftedArray` with a compatible default value,
+    the constructor does not nest `MutableShiftedArray` objects but rather combines
+    the shifts additively.
+
+# Examples
+
+```jldoctest shiftedarray
+julia> v = [1, 3, 5, 4];
+
+julia> s = MutableShiftedArray(v, (1,))
+4-element MutableShiftedArray{Int64, Missing, Vector{Int64}}:
+  missing
+ 1
+ 3
+ 5
+
+julia> v = [1, 3, 5, 4];
+
+julia> s = MutableShiftedArray(v, (1,))
+4-element MutableShiftedArray{Int64, Missing, Vector{Int64}}:
+  missing
+ 1
+ 3
+ 5
+
+julia> copy(s)
+4-element Vector{Union{Missing, Int64}}:
+  missing
+ 1
+ 3
+ 5
+
+julia> v = reshape(1:16, 4, 4);
+
+julia> s = MutableShiftedArray(v, (0, 2))
+4×4 MutableShiftedArray{Int64, Missing, 2, Base.ReshapedArray{Int64, 2, UnitRange{Int64}, Tuple{}}}:
+ missing  missing  1  5
+ missing  missing  2  6
+ missing  missing  3  7
+ missing  missing  4  8
+
+julia> shifts(s)
+(0, 2)
+```
+"""
+struct MutableShiftedArray{T, M, N, S<:AbstractArray} <: AbstractArray{Union{T, M}, N}
+    parent::S
+    shifts::NTuple{N, Int}
+    default::M
+end
+
+# low-level private constructor to handle type parameters
+function mutableshiftedarray(v::AbstractArray{T, N}, shifts, default::M) where {T, N, M}
+    return MutableShiftedArray{T, M, N, typeof(v)}(v, padded_tuple(v, shifts), default)
+end
+
+function MutableShiftedArray(v::AbstractArray, n = (); default = ShiftedArrays.default(v))
+    return if (v isa MutableShiftedArray || v isa ShiftedArray) && default === ShiftedArrays.default(v)
+        shifts = map(+, ShiftedArrays.shifts(v), padded_tuple(v, n))
+        mutableshiftedarray(parent(v), shifts, default)
+    else
+        mutableshiftedarray(v, n, default)
+    end
+end
+
+"""
+    MutableShiftedVector{T, S<:AbstractArray}
+
+Shorthand for `MutableShiftedArray{T, 1, S}`.
+"""
+const MutableShiftedVector{T, M, S<:AbstractArray} = MutableShiftedArray{T, M, 1, S}
+
+function MutableShiftedVector(v::AbstractVector, n = (); default = ShiftedArrays.default(v))
+    return MutableShiftedArray(v, n; default = default)
+end
+
+size(s::MutableShiftedArray) = size(parent(s))
+axes(s::MutableShiftedArray) = axes(parent(s))
+
+# Computing a shifted index (subtracting the offset)
+offset(offsets::NTuple{N,Int}, inds::NTuple{N,Int}) where {N} = map(-, inds, offsets)
+
+@inline function getindex(s::MutableShiftedArray{<:Any, <:Any, N}, x::Vararg{Int, N}) where {N}
+    @boundscheck checkbounds(s, x...)
+    v, i = parent(s), offset(shifts(s), x)
+    return if checkbounds(Bool, v, i...)
+        @inbounds v[i...]
+    else
+        default(s)
+    end
+end
+
+@inline function setindex!(s::MutableShiftedArray{<:Any, <:Any, N}, el, x::Vararg{Int, N}) where {N}
+    @boundscheck checkbounds(s, x...)
+    v, i = parent(s), offset(shifts(s), x)
+    if checkbounds(Bool, v, i...)
+        @inbounds v[i...] = el
+    end
+    return s
+end
+
+parent(s::MutableShiftedArray) = s.parent
+
+"""
+    shifts(s::ShiftedArray)
+
+Return amount by which `s` is shifted compared to `parent(s)`.
+"""
+shifts(s::MutableShiftedArray) = s.shifts
+
+"""
+    default(s::MutableShiftedArray)
+
+Return default value.
+"""
+default(s::MutableShiftedArray) = s.default
+
+default(::AbstractArray) = missing

--- a/src/shiftedarray.jl
+++ b/src/shiftedarray.jl
@@ -48,15 +48,6 @@ julia> s = ShiftedArray(v, (1,))
  3
  5
 
-julia> v = [1, 3, 5, 4];
-
-julia> s = ShiftedArray(v, (1,))
-4-element ShiftedVector{Int64, Missing, Vector{Int64}}:
-  missing
- 1
- 3
- 5
-
 julia> copy(s)
 4-element Vector{Union{Missing, Int64}}:
   missing

--- a/src/shiftedarray.jl
+++ b/src/shiftedarray.jl
@@ -89,7 +89,7 @@ function shiftedarray(v::AbstractArray{T, N}, shifts, default::M) where {T, N, M
 end
 
 function ShiftedArray(v::AbstractArray, n = (); default = ShiftedArrays.default(v))
-    return if v isa ShiftedArray && default === ShiftedArrays.default(v)
+    return if (v isa MutableShiftedArray || v isa ShiftedArray) && default === ShiftedArrays.default(v)
         shifts = map(+, ShiftedArrays.shifts(v), padded_tuple(v, n))
         shiftedarray(parent(v), shifts, default)
     else

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,6 @@
 using ShiftedArrays, Test
 using AbstractFFTs 
-use_cuda = true;  # set this to true to test ShiftedArrays for the CuArray datatype
+use_cuda = false;  # set this to true to test ShiftedArrays for the CuArray datatype
 if (use_cuda)
     using CUDA
     CUDA.allowscalar(true); # needed for some of the comparisons

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,6 @@
 using ShiftedArrays, Test
 using AbstractFFTs 
-use_cuda = false;  # set this to true to test ShiftedArrays for the CuArray datatype
+use_cuda = true;  # set this to true to test ShiftedArrays for the CuArray datatype
 if (use_cuda)
     using CUDA
     CUDA.allowscalar(true); # needed for some of the comparisons

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -77,6 +77,58 @@ end
                                  0  1         5         9      ])
 end
 
+@testset "MutableShiftedArray" begin
+    v = collect(reshape(1:16, 4, 4))  # index assignment to reshaped ranges is not supported
+    v = opt_convert(v);
+    @test all(v .== MutableShiftedArray(v))
+    sv = MutableShiftedArray(v, (-2, 0))
+    @test length(sv) == 16
+    @test sv[1, 3] == 11
+    @test ismissing(sv[3, 3])
+    @test shifts(sv) == (-2,0)
+    @test isequal(sv, MutableShiftedArray(v, -2))
+    @test isequal(@inferred(MutableShiftedArray(v, (2,))), @inferred(MutableShiftedArray(v, 2)))
+    @test isequal(@inferred(MutableShiftedArray(v)), @inferred(MutableShiftedArray(v, (0, 0))))
+    s = MutableShiftedArray(v, (0, -2))
+    @test isequal(collect(s), [ 9 13 missing missing;
+                               10 14 missing missing;
+                               11 15 missing missing;
+                               12 16 missing missing])
+    sneg = MutableShiftedArray(v, (0, -2), default = -100)
+    @test all(sneg .== coalesce.(s, default(sneg)))
+    @test checkbounds(Bool, sv, 2, 2)
+    @test !checkbounds(Bool, sv, 123, 123)
+    svnest = MutableShiftedArray(MutableShiftedArray(v, (1, 1)), 2)
+    sv = MutableShiftedArray(v, (3, 1))
+    @test sv === svnest
+    sv = MutableShiftedArray(v, 2, default = nothing)
+    sv1 = MutableShiftedArray(sv, (1, 1))
+    sv2 = MutableShiftedArray(sv, (1, 1), default = 0)
+    @test isequal(collect(sv1), [nothing   nothing   nothing   nothing
+                                 nothing   nothing   nothing   nothing
+                                 nothing   nothing   nothing   nothing
+                                 nothing  1         5         9      ])
+    @test isequal(collect(sv2), [0  0         0         0
+                                 0   nothing   nothing   nothing
+                                 0   nothing   nothing   nothing
+                                 0  1         5         9      ])
+
+    # test some mutation operations
+    sv[1,1] = 0
+    @test sv[1,1] == nothing
+    sv[3,3] = 0
+    @test sv[3,3] == 0
+    @test v[1,3] == 0
+    @test sv1[4,4] == 0
+    sv1[4,4] = 55
+    @test v[1,3] == 55
+    sv1[:,:] .= -1
+    @test v[1,1] == -1
+    @test v[1,4] == 13
+    sv2[:] .= -2
+    @test sv2[4,2] == -2
+end
+
 @testset "padded_tuple" begin
     v = rand(2, 2)
     v = opt_convert(v);


### PR DESCRIPTION
This PR includes the changes of the other PR. It thus contains CUDA support.
In addition a new datatype `MutableShiftedArray` is added, which is essentially copy-paste of the code of the `ShiftedArray` type. However it supports the `setindex!` function. 
An alternative could have been to simply add the `setindex!` function to the `ShiftedArray` type, but this can potentially lead to backwards compatibility issues, which is why I opted for this version with another type.
The CUDA Adapt methods of this new type are also supported and I added some tests for the mutatation operation. 
Note that mutation of places hosting the `default` type, are silently ignored. Which is what the typical use-case would want. However, it does feel slightly odd and may lead to trouble for some code which relies on the fact that a mutation really changes a place and a subsequent read operation reflects this change. 